### PR TITLE
/opt/*/include, /opt/*/lib are alternative paths on MacOS

### DIFF
--- a/cmake/Modules/FindLibUSB.cmake
+++ b/cmake/Modules/FindLibUSB.cmake
@@ -5,7 +5,12 @@ if(NOT LIBUSB_FOUND)
     ${LIBUSB_PKG_INCLUDE_DIRS}
     /usr/include/libusb-1.0
     /usr/include
+    /usr/local/include/libusb-1.0
     /usr/local/include
+    /opt/include/libusb-1.0
+    /opt/include
+    /opt/local/include/libusb-1.0
+    /opt/local/include
   )
 
 #standard library name for libusb-1.0
@@ -22,6 +27,8 @@ endif()
     ${LIBUSB_PKG_LIBRARY_DIRS}
     /usr/lib
     /usr/local/lib
+    /opt/lib
+    /opt/local/lib
   )
 
 include(CheckFunctionExists)


### PR DESCRIPTION
Specifically, MacPorts installs libraries in /opt/local/

On branch macports_compatibility

	modified:   cmake/Modules/FindLibUSB.cmake